### PR TITLE
Make JNI code compilable with NDK r10e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+libs
+obj

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -5,4 +5,4 @@ APP_STL := stlport_static
 APP_PLATFORM := android-9
 APP_OPTIM := release
 
-NDK_TOOLCHAIN_VERSION := 4.6
+NDK_TOOLCHAIN_VERSION := 4.8

--- a/jni/dosbox/Android.mk
+++ b/jni/dosbox/Android.mk
@@ -24,8 +24,7 @@ src/shell \
 
 MY_PATH := $(LOCAL_PATH)
 
-#Fix me
-LOCAL_PATH := "/home/gene/workspace/com.fishstix.dosboxfree/jni/dosbox"
+LOCAL_PATH := $(abspath $(LOCAL_PATH))
 
 CG_SRCDIR := $(LOCAL_PATH)
 LOCAL_CFLAGS :=	-I$(LOCAL_PATH)/include \

--- a/jni/fishstix/Android.mk
+++ b/jni/fishstix/Android.mk
@@ -7,8 +7,7 @@ CG_SUBDIRS := .\
 
 MY_PATH := $(LOCAL_PATH)
 
-
-LOCAL_PATH := "/home/gene/workspace/com.fishstix.dosboxfree/jni/fishstix"
+LOCAL_PATH := $(abspath $(LOCAL_PATH))
 
 CG_SRCDIR := $(LOCAL_PATH)
 LOCAL_CFLAGS :=	-I$(LOCAL_PATH)/include \

--- a/jni/fishstix_al/Android.mk
+++ b/jni/fishstix_al/Android.mk
@@ -10,7 +10,7 @@ CG_SUBDIRS := .\
 
 MY_PATH := $(LOCAL_PATH)
 
-LOCAL_PATH := "/home/gene/workspace/com.fishstix.dosboxfree/jni/fishstix_al"
+LOCAL_PATH := $(abspath $(LOCAL_PATH))
 
 CG_SRCDIR := $(LOCAL_PATH)
 LOCAL_CFLAGS :=	-I$(LOCAL_PATH)/include \

--- a/jni/fishstix_util/Android.mk
+++ b/jni/fishstix_util/Android.mk
@@ -10,7 +10,7 @@ CG_SUBDIRS := .\
 
 MY_PATH := $(LOCAL_PATH)
 
-LOCAL_PATH := "/home/gene/workspace/com.fishstix.dosboxfree/jni/fishstix_util"
+LOCAL_PATH := $(abspath $(LOCAL_PATH))
 
 CG_SRCDIR := $(LOCAL_PATH)
 LOCAL_CFLAGS :=	-I$(LOCAL_PATH)/include \


### PR DESCRIPTION
- Replaced hard-coded values for LOCAL_PATH inside .mk files
- Fixed JNI-build for NDK r10e
- Added .gitignore
